### PR TITLE
Fix default dataset reading and mineral mass calc

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ python app.py
 | bd_i | soc_i | bd_n | soc_n | depth |
 |------|-------|------|-------|-------|
 | 1.5  | 0.014 | 1.1  | 0.016 | 30    |
+
+On first launch the app loads `data/default.xlsx`, which contains the worked
+example from the Nature 2023 paper. The file is parsed automatically and the
+corrected SOC stock is shown using the fixed-depth method.

--- a/app.py
+++ b/app.py
@@ -37,18 +37,25 @@ def index():
                             'corrected_stock': corr})
         return render_template('results.html', results=results, method=method)
 
-    df = pd.read_excel(DATA_PATH)
+    df = pd.read_excel(DATA_PATH, header=5).iloc[1:].reset_index(drop=True)
     results = []
-    for _, row in df.iterrows():
-        bd_i, soc_i, bd_n, soc_n = row[['bd_i','soc_i','bd_n','soc_n']]
-        depth = row.get('depth', 30)
+    for i in range(0, len(df)-1, 2):
+        base = df.iloc[i]
+        new = df.iloc[i+1]
+        depth = float(base['Depth _cm'])
+        bd_i = float(base['BD _g/cm3'])
+        soc_i = float(base['SOC_%']) / 100
+        bd_n = float(new['BD _g/cm3'])
+        soc_n = float(new['SOC_%']) / 100
         Da, orig, corr = esm_correction_fixed(bd_i, soc_i, bd_n, soc_n, depth)
         results.append({
-            'bd_i': bd_i, 'soc_i': soc_i,
-            'bd_n': bd_n, 'soc_n': soc_n,
+            'bd_i': bd_i,
+            'soc_i': soc_i,
+            'bd_n': bd_n,
+            'soc_n': soc_n,
             'depth': depth,
             'adjusted_depth': Da,
-            'corrected_stock': corr
+            'corrected_stock': corr * 1e4
         })
     return render_template('results.html', results=results, method='fixed (default)')
 

--- a/esm_calculations.py
+++ b/esm_calculations.py
@@ -1,7 +1,29 @@
 import numpy as np
 
 def compute_mineral_mass(bd, depth, soc, k=1.9):
-    MT = bd * depth * 1e4 * 1e-6
+    """Compute mineral mass in Mg/ha.
+
+    Parameters
+    ----------
+    bd : float
+        Bulk density in g/cm^3.
+    depth : float
+        Sample depth in cm.
+    soc : float
+        Soil organic carbon fraction (0-1).
+    k : float, optional
+        van Bemmelen factor.
+
+    Returns
+    -------
+    float
+        Mineral mass (Mg/ha).
+    """
+
+    # Convert bulk density and depth to Mg/ha of soil mass. 1 g/cm^3 is
+    # equivalent to 1 Mg/m^3. A hectare is 10,000 m^2, so the mass of a soil
+    # layer is ``bd * depth/100 * 10_000``.
+    MT = bd * depth * 100
     return MT * (1 - k * soc)
 
 def esm_correction_fixed(bd_i, soc_i, bd_n, soc_n, depth=30, k=1.9):


### PR DESCRIPTION
## Summary
- fix `compute_mineral_mass` unit calculation
- parse `data/default.xlsx` correctly for default results
- mention built‑in dataset in README

## Testing
- `python -m py_compile app.py esm_calculations.py`
- `python - <<'PY'
from app import index, app
with app.test_request_context('/'):
    resp = index()
    print(resp)
PY`

------
https://chatgpt.com/codex/tasks/task_e_687d4e2ce7c48321b95ffa78fa85e577