### PR TITLE
Handle ESM calculations across time

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,13 @@
 
 This repository now contains a static implementation of the Equivalent Soil Mass calculator. All calculations are performed in the browser using JavaScript so the site can be hosted on GitHub Pages.
 
-Upload a CSV containing the columns below or experiment with the included `data/default_clean.csv` dataset.
+Upload a CSV with the columns below. The `data/default_clean.csv` file provides an example.
 
-| bd_i | soc_i | bd_n | soc_n | depth |
-|------|-------|------|-------|-------|
-| 1.5  | 0.014 | 1.1  | 0.016 | 30    |
+| Time | Interval_cm | BottomDepth_cm | SoilMass_Mg_ha | SOC_percent | BD_g_cm3 |
+|------|-------------|---------------|----------------|-------------|----------|
+| T0   | 15          | 15            | 2134           | 1.84        | 1.42     |
+| T0   | 15          | 30            | 2366           | 1.01        | 1.58     |
+| T1   | 15          | 15            | 1781           | 1.93        | 1.19     |
+| T1   | 15          | 30            | 2083           | 1.13        | 1.39     |
 
-Open `index.html` in a browser (or deploy the repository via GitHub Pages) to use the calculator. Both the fixed depth and profile based methods are implemented.
+Open `index.html` in a browser (or deploy the repository via GitHub Pages) to use the calculator. The app computes the equivalent soil mass for each time point and the change relative to the first time in the file.

--- a/data/default_clean.csv
+++ b/data/default_clean.csv
@@ -1,2 +1,5 @@
-bd_i,soc_i,bd_n,soc_n,depth
-1.5,0.013999999999999999,1.3,0.015,30.0
+Time,Interval_cm,BottomDepth_cm,SoilMass_Mg_ha,SOC_percent,BD_g_cm3
+T0,15,15,2134,1.84,1.42
+T0,15,30,2366,1.01,1.58
+T1,15,15,1781,1.93,1.19
+T1,15,30,2083,1.13,1.39

--- a/index.html
+++ b/index.html
@@ -5,25 +5,47 @@
   <title>ESM Calculator</title>
   <script src="https://cdn.jsdelivr.net/npm/papaparse@5.3.2/papaparse.min.js"></script>
   <script src="js/esm.js"></script>
+  <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
   <style>
-    table, th, td { border: 1px solid #ccc; border-collapse: collapse; }
-    th, td { padding: 4px 8px; }
+    body {
+      font-family: 'Roboto', sans-serif;
+      max-width: 800px;
+      margin: auto;
+      padding: 2rem;
+      background: #f8f9fa;
+      color: #333;
+    }
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 1rem;
+    }
+    th, td {
+      border: 1px solid #ccc;
+      padding: 6px 10px;
+    }
+    th {
+      background: #343a40;
+      color: #fff;
+    }
+    tr:nth-child(even) { background: #e9ecef; }
+    h1 { text-align: center; }
+    form { margin-bottom: 1rem; text-align: center; }
   </style>
 </head>
 <body>
   <h1>ESM Calculator</h1>
-  <p><em>On first visit, we’ve pre-loaded the Nature2023 dataset so you can see how it works.</em></p>
+  <p><em>Upload a CSV containing <code>Time, Interval_cm, BottomDepth_cm, SoilMass_Mg_ha, SOC_percent, BD_g_cm3</code>. The included file demonstrates the expected format.</em></p>
   <form id="form">
     <input type="file" id="csvfile" accept=".csv">
-    <label><input type="radio" name="method" value="fixed" checked> Fixed-depth method</label>
-    <label><input type="radio" name="method" value="profile"> Profile-based method</label>
     <button type="submit">Compute</button>
   </form>
   <table id="results">
     <thead>
       <tr>
-        <th>bd_i</th><th>soc_i</th><th>bd_n</th><th>soc_n</th>
-        <th>depth</th><th>adjusted_depth</th><th>corrected_stock</th>
+        <th>Time</th>
+        <th>Corrected Stock</th>
+        <th>Delta from T0</th>
       </tr>
     </thead>
     <tbody></tbody>
@@ -31,50 +53,35 @@
   <script>
   document.addEventListener('DOMContentLoaded', function() {
     const tableBody = document.querySelector('#results tbody');
-    function compute(rows, method) {
+
+    function render(results) {
       tableBody.innerHTML = '';
-      rows.forEach(r => {
-        if (!r.bd_i) return;
-        const bd_i = parseFloat(r.bd_i);
-        const soc_i = parseFloat(r.soc_i);
-        const bd_n = parseFloat(r.bd_n);
-        const soc_n = parseFloat(r.soc_n);
-        const depth = parseFloat(r.depth || 30);
-        let Da = '';
-        let corr = 0;
-        if (method === 'fixed') {
-          const res = esmCorrectionFixed(bd_i, soc_i, bd_n, soc_n, depth);
-          Da = res.Da.toFixed(6);
-          corr = res.corrected.toFixed(6);
-        } else {
-          const inc = 1;
-          const bd_i_p = linearBdProfile(bd_i, bd_i, depth, inc);
-          const soc_i_p = exponentialSocProfile(soc_i, soc_i, depth, 0, inc);
-          const bd_n_p = linearBdProfile(bd_n, bd_n, depth, inc);
-          const soc_n_p = exponentialSocProfile(soc_n, soc_n, depth, 0, inc);
-          corr = esmCorrectionProfile(bd_i_p, soc_i_p, bd_n_p, soc_n_p, depth, inc).toFixed(6);
-        }
+      results.forEach(r => {
         const tr = document.createElement('tr');
-        tr.innerHTML = `<td>${bd_i}</td><td>${soc_i}</td><td>${bd_n}</td><td>${soc_n}</td><td>${depth}</td><td>${Da}</td><td>${corr}</td>`;
+        tr.innerHTML = `<td>${r.time}</td><td>${r.corrected.toFixed(6)}</td><td>${r.delta.toFixed(6)}</td>`;
         tableBody.appendChild(tr);
       });
+    }
+
+    function compute(rows) {
+      const results = esmDeltas(rows);
+      render(results);
     }
 
     fetch('data/default_clean.csv')
       .then(resp => resp.text())
       .then(text => {
-        Papa.parse(text, {header:true, skipEmptyLines:true, complete: res => compute(res.data, 'fixed')});
+        Papa.parse(text, {header:true, skipEmptyLines:true, complete: res => compute(res.data)});
       });
 
     document.getElementById('form').addEventListener('submit', function(e) {
       e.preventDefault();
-      const method = document.querySelector('input[name="method"]:checked').value;
       const file = document.getElementById('csvfile').files[0];
       if (!file) return;
       Papa.parse(file, {
         header:true,
         skipEmptyLines:true,
-        complete: res => compute(res.data, method)
+        complete: res => compute(res.data)
       });
     });
   });


### PR DESCRIPTION
## Summary
- modernize the UI with Roboto and lighter styles
- read time-based CSVs and compute ESM change over time
- provide a helper `esmDeltas` function
- update example dataset and docs for the new format

## Testing
- `node --check js/esm.js`
- `node - <<'EOF'
  global.window = {};
  const Papa = require('papaparse');
  const fs = require('fs');
  require('./js/esm.js');
  const text = fs.readFileSync('data/default_clean.csv','utf8');
  const rows = Papa.parse(text,{header:true,skipEmptyLines:true}).data;
  console.log(window.esmDeltas(rows));
  EOF

------
https://chatgpt.com/codex/tasks/task_e_687d5d8d2fd4832193052507c19dd43d